### PR TITLE
Removed malloc.h include to support macOS

### DIFF
--- a/src/dotenv.c
+++ b/src/dotenv.c
@@ -1,8 +1,10 @@
 #include <stdio.h>
-#include <malloc.h>
 #include <memory.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#ifndef __APPLE__
+#include <malloc.h>
+#endif
 
 
 /* strtok_r() won't remove the whole ${ part, only the $ */

--- a/src/dotenv.c
+++ b/src/dotenv.c
@@ -2,10 +2,6 @@
 #include <memory.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
-
 
 /* strtok_r() won't remove the whole ${ part, only the $ */
 #define remove_bracket(name) name + 1


### PR DESCRIPTION
I noticed a compilation error on Mac:

```
src/dotenv.c:2:10: fatal error: 'malloc.h' file not found
```

Found out that that is because `malloc.h` is a [non standard header](https://stackoverflow.com/questions/12973311/difference-between-stdlib-h-and-malloc-h), which is not available on Mac.

Made header conditional, it's now excluded on Mac.