### PR TITLE
Added support for Windows, with Clang + MSVC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - name: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
       shell: bash
       run: |
         mkdir -p build && cd build 
-        cmake -DOTENV_TEST=ON ..
+        cmake -DDOTENV_TEST=ON ..
         cmake --build .
         ./dotenv-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: make test
-      run: make test
+      shell: bash
+      run: |
+        mkdir -p build && cd build 
+        cmake -DOTENV_TEST=ON ..
+        cmake --build .
+    - name: run test
+      run: ./dotenv-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,5 @@ jobs:
         mkdir -p build && cd build 
         cmake -DDOTENV_TEST=ON ..
         cmake --build .
-        ./dotenv-test
+        cmake install
+        dotenv-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
         cmake -DOTENV_TEST=ON ..
         cmake --build .
     - name: run test
-      run: ./dotenv-test
+      run: ./build/dotenv-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,4 @@ jobs:
         mkdir -p build && cd build 
         cmake -DDOTENV_TEST=ON ..
         cmake --build .
-        cmake install
-        dotenv-test
+        ctest --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: make test
+    - name: make and run test
       shell: bash
       run: |
         mkdir -p build && cd build 
         cmake -DOTENV_TEST=ON ..
         cmake --build .
-    - name: run test
-      run: ./build/dotenv-test
+        ./dotenv-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
         mkdir -p build && cd build 
         cmake -DDOTENV_TEST=ON ..
         cmake --build .
-        ctest --verbose
+        ctest -C Debug --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,4 +62,7 @@ if (DOTENV_TEST)
     add_executable(${DOTENV_C_TEST} ${DOTENV_C_TEST_SRC})
     target_include_directories(${DOTENV_C_TEST} PRIVATE ${DOTENV_C_INCLUDE})
     target_compile_options(${DOTENV_C_TEST} PRIVATE ${DOTENV_COMPILE_OPTIONS})
+
+    configure_file(test/.env ${CMAKE_BINARY_DIR}/test/.env COPYONLY)
+    configure_file(test/.test.env ${CMAKE_BINARY_DIR}/test/.test.env COPYONLY)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,13 @@ if (DOTENV_STATIC)
 endif()
 
 if (DOTENV_TEST)
+    enable_testing()
     add_executable(${DOTENV_C_TEST} ${DOTENV_C_TEST_SRC})
     target_include_directories(${DOTENV_C_TEST} PRIVATE ${DOTENV_C_INCLUDE})
     target_compile_options(${DOTENV_C_TEST} PRIVATE ${DOTENV_COMPILE_OPTIONS})
 
     configure_file(test/.env ${CMAKE_BINARY_DIR}/test/.env COPYONLY)
     configure_file(test/.test.env ${CMAKE_BINARY_DIR}/test/.test.env COPYONLY)
+
+    add_test(NAME ${DOTENV_C_TEST} COMMAND ${DOTENV_C_TEST})
 endif()

--- a/src/dotenv.c
+++ b/src/dotenv.c
@@ -168,7 +168,7 @@ static void parse(FILE *file, bool overwrite)
 
 static FILE *open_default(const char *base_path)
 {
-    char path[strlen(base_path) + strlen(".env") + 1];
+    char path[512];
     sprintf(path, "%s/.env", base_path);
 
     return fopen(path, "rb");

--- a/src/dotenv.c
+++ b/src/dotenv.c
@@ -1,7 +1,63 @@
+#include "dotenv.h"
 #include <stdio.h>
 #include <memory.h>
 #include <stdlib.h>
 #include <stdbool.h>
+
+#if (defined(_WIN32) || defined(_MSC_VER)) && !defined(__MINGW32__)
+
+#include <string.h>
+#define strtok_r strtok_s
+
+int setenv(const char *name, const char *value, int overwrite) {
+    int errcode = 0;
+    if (!overwrite) {
+        size_t envsize = 0;
+        errcode        = getenv_s(&envsize, NULL, 0, name);
+        if (errcode || envsize)
+            return errcode;
+    }
+    return _putenv_s(name, value);
+}
+
+// https://dev.w3.org/libwww/Library/src/vms/getline.c
+int getline(char **lineptr, size_t *n, FILE *stream) {
+    static char  line[256];
+    char        *ptr;
+    unsigned int len;
+
+    if (lineptr == NULL || n == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ferror(stream))
+        return -1;
+
+    if (feof(stream))
+        return -1;
+
+    fgets(line, 256, stream);
+
+    ptr = strchr(line, '\n');
+    if (ptr)
+        *ptr = '\0';
+
+    len = strlen(line);
+
+    if ((len + 1) < 256) {
+        ptr = realloc(*lineptr, 256);
+        if (ptr == NULL)
+            return (-1);
+        *lineptr = ptr;
+        *n       = 256;
+    }
+
+    strcpy(*lineptr, line);
+    return (len);
+}
+
+#endif
 
 /* strtok_r() won't remove the whole ${ part, only the $ */
 #define remove_bracket(name) name + 1

--- a/src/dotenv.c
+++ b/src/dotenv.c
@@ -39,7 +39,7 @@ int getline(char **lineptr, size_t *n, FILE *stream) {
 
     fgets(line, 256, stream);
 
-    ptr = strchr(line, '\n');
+    ptr = strstr(line, "\r\n");
     if (ptr)
         *ptr = '\0';
 

--- a/test/env_test.c
+++ b/test/env_test.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include "assert.h"
 
+#if defined(_WIN32)
+#include <string.h>
+#endif
 
 #define assert_var(expected, name) \
     assert(0 == strcmp(expected, getenv(name)))


### PR DESCRIPTION
This PR adds support for Windows, using Clang compiler & linkage to MSVC. 

I also had some issue with export symbols ` __declspec(dllexport)` . Otherwise it worked without a problem on Windows platform.  

Thank you for this work ! 